### PR TITLE
Run tests on python 2.7 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
 
 python:
+    - 3.7
     - 3.6
     - 3.5
     - 3.4
+    - 2.7
 
 sudo: required
 
@@ -18,6 +20,7 @@ script:
     - ./tests/scripts/shell/test_funky.sh
 
 os: linux
+dist: xenial
 
 addons:
   apt:


### PR DESCRIPTION
This will run tests on python 2.7 and 3.7
I had do add: `dist: xenial` because python 3.7 isn't available for `trusty`

**Known issue:**
- Tests fail on python 2.7 due to `unittest.mock` not being available. Should use [mock](https://pypi.org/project/mock/)

Closes #136 