### PR TITLE
Fix: install funky.sh to $XDG_DATA_HOME/funky instead of $XDG_DATA_HOME

### DIFF
--- a/scripts/post_install.py
+++ b/scripts/post_install.py
@@ -18,7 +18,7 @@ def _copy_sh_ext(install):
     root = install.root if install.root else ''
 
     if 'XDG_DATA_HOME' in os.environ:
-        xdg_data_dir = root + os.environ['XDG_DATA_HOME']
+        xdg_data_dir = root + os.environ['XDG_DATA_HOME'] + "/funky"
     else:
         home = 'Users' if sys.platform == 'darwin' else 'home'
         user = getpass.getuser()


### PR DESCRIPTION
The previous behaviour was inconsistent with README.md.

This issue came up when creating the Arch Linux package https://aur.archlinux.org/packages/funky-git/.